### PR TITLE
Add uncertainty_tools package

### DIFF
--- a/carma_utils/include/carma_utils/CARMANodeHandle.h
+++ b/carma_utils/include/carma_utils/CARMANodeHandle.h
@@ -243,6 +243,8 @@ namespace ros {
         const M_string & 	remappings = M_string() 
       );	
 
+      CARMANodeHandle	(	const NodeHandle & 	rhs	);
+
       CARMANodeHandle	(	const CARMANodeHandle & 	rhs	);
 
       CARMANodeHandle	(	const CARMANodeHandle & 	parent,

--- a/carma_utils/src/carma_utils/CARMANodeHandle.cpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.cpp
@@ -46,6 +46,12 @@ namespace ros {
 
    CARMANodeHandle::SpinCB CARMANodeHandle::spin_cb_;
 
+  CARMANodeHandle::CARMANodeHandle( const NodeHandle & 	rhs	) 
+    : NodeHandle(rhs) 
+  {
+    initPubSub();
+  }
+
   CARMANodeHandle::CARMANodeHandle(	const std::string & ns, const M_string & 	remappings)
     : NodeHandle(ns, remappings) 
   {

--- a/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
+++ b/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
@@ -229,6 +229,10 @@ TEST(CARMANodeHandleTests, testCARMANodeHandleConstructor)
     "g",
     remappings 
   );
+
+  NodeHandle nh;
+
+  CARMANodeHandle cnh5(nh);
 }
 
 TEST(CARMANodeHandleTests, testCARMANodeHandleSubscriber)

--- a/uncertainty_tools/CMakeLists.txt
+++ b/uncertainty_tools/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(uncertainty_tools)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS)
+
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  # CATKIN_DEPENDS roscpp
+  # DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+ include
+  ${catkin_INCLUDE_DIRS}
+)
+
+file(GLOB_RECURSE headers */*.hpp */*.h)
+
+add_library(${PROJECT_NAME} src/${PROJECT_NAME}/${PROJECT_NAME}.cpp)
+target_link_libraries(${PROJECT_NAME})
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+
+
+#############
+## Install ##
+#############
+
+## Mark executables and/or libraries for installation
+ install(TARGETS ${PROJECT_NAME}
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ )
+
+## Mark cpp header files for installation
+ install(DIRECTORY include/${PROJECT_NAME}/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN "*.h"
+   PATTERN ".svn" EXCLUDE
+ )
+
+##########
+## Test ##
+##########
+
+# SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+catkin_add_gmock(${PROJECT_NAME}-test test/${PROJECT_NAME}/uncertainty_tools_test.cpp)
+if(TARGET ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+endif()

--- a/uncertainty_tools/include/uncertainty_tools/uncertainty_tools.h
+++ b/uncertainty_tools/include/uncertainty_tools/uncertainty_tools.h
@@ -1,0 +1,32 @@
+#pragma once
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <vector>
+#include <tuple>
+
+namespace uncertainty_tools {
+  /**
+   * \brief Function to compute magnitude with an uncertainty value from component vectors containing their own uncertainties
+   * 
+   * \param values List of vector component values for a 3 dimensional space with should be a 3 element list. 1 value for each component
+   * \param uncertainties List of vector uncertainties (95% confidence interval). Each value should match an element in the values list
+   * \throws std::invalid_argument if the input values list and uncertainties list have unequal sizes or a size of 0
+   * 
+   * \return An std::tuple where the first value is the resultant magnitude and the second value is that magnitudes uncertainty.
+   */ 
+  std::tuple<double,double> computeVectorMagnitudeAndUncertainty(const std::vector<double>& values, const std::vector<double>& uncertainties);
+};

--- a/uncertainty_tools/package.xml
+++ b/uncertainty_tools/package.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>uncertainty_tools</name>
+  <version>0.0.1</version>
+  <description>The uncertainty_tools contains useful functions for dealing with uncertainty in calculations </description>
+  <maintainer email="carma@todo.todo">carma</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="carma@todo.todo">carma</author>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/uncertainty_tools/src/uncertainty_tools/uncertainty_tools.cpp
+++ b/uncertainty_tools/src/uncertainty_tools/uncertainty_tools.cpp
@@ -1,0 +1,58 @@
+#pragma once
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <string>
+#include <vector>
+#include <tuple>
+#include <math.h>
+#include <exception>
+#include <uncertainty_tools/uncertainty_tools.h>
+
+
+namespace uncertainty_tools {
+
+  std::tuple<double,double> computeVectorMagnitudeAndUncertainty(
+    const std::vector<double>& values, const std::vector<double>& uncertainties
+  ) {
+    // An example of the math used to compute uncertainties of resultant vectors can be found here
+    // http://spiff.rit.edu/classes/phys216/workshops/w2x/hypotenuse.html
+
+    if (values.size() == 0 || values.size() != uncertainties.size()) {
+      throw std::invalid_argument("Invalid: Input values list and uncertainties list have unequal sizes or a size of 0");
+    }
+
+    double sum_of_unc_sqr = 0;
+    double sum_of_sqr_val = 0;
+    for (int i=0; i<values.size(); i++) {
+      const double val = values[i];
+      const double unc = uncertainties[i];
+      const double val_sqr = val * val;
+
+      const double frac_unc_of_sqr = 2*(unc/val);
+      const double unc_of_sqr = frac_unc_of_sqr * val_sqr;
+      sum_of_unc_sqr += unc_of_sqr;
+      sum_of_sqr_val += val_sqr;
+    }
+
+    const double resultant_mag = sqrt(sum_of_sqr_val);
+    const double frac_var_of_resultant_sqr = sum_of_unc_sqr / sum_of_sqr_val;
+    const double frac_var_of_resultant = 0.5 * frac_var_of_resultant_sqr;
+    const double var_of_resultant = resultant_mag * frac_var_of_resultant;
+
+    return std::make_tuple(resultant_mag, var_of_resultant);
+  }
+};

--- a/uncertainty_tools/test/uncertainty_tools/uncertainty_tools_test.cpp
+++ b/uncertainty_tools/test/uncertainty_tools/uncertainty_tools_test.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <uncertainty_tools/uncertainty_tools.h>
+
+
+using ::testing::A;
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::Unused;
+
+
+TEST(uncertainty_tools_test, TestComputeVectorMagnitudeAndUncertainty)
+{   
+  // Test calculation
+  std::vector<double> components, uncertainties;
+  components.push_back(5.3);
+  uncertainties.push_back(0.2);
+
+  components.push_back(15.4);
+  uncertainties.push_back(0.3);
+
+  std::tuple<double,double> result = uncertainty_tools::computeVectorMagnitudeAndUncertainty(components, uncertainties);
+  ASSERT_NEAR(16.3, std::get<0>(result), 0.1);
+  ASSERT_NEAR(0.3, std::get<1>(result), 0.1);
+
+  // Test throw behavior
+  // First list empty
+  try {
+    std::vector<double> componentsE;
+    std::tuple<double,double> result = uncertainty_tools::computeVectorMagnitudeAndUncertainty(componentsE, uncertainties);
+    FAIL() << "Exception not thrown when provided with empty lists";
+  } catch (const std::invalid_argument& e) {
+    // PASS
+  } catch (const std::exception& e) {
+    FAIL() << "Exception thrown not of expected type std::invalid_argument. Instead: " << e.what();
+  }
+
+  // Second list empty
+  try {
+    std::vector<double> uncertaintiesE;
+    std::tuple<double,double> result = uncertainty_tools::computeVectorMagnitudeAndUncertainty(components, uncertaintiesE);
+    FAIL() << "Exception not thrown when provided with empty lists";
+  } catch (const std::invalid_argument& e) {
+    // PASS
+  } catch (const std::exception& e) {
+    FAIL() << "Exception thrown not of expected type std::invalid_argument. Instead: " << e.what();
+  }
+
+  // Both list empty
+  try {
+    std::vector<double> componentsE, uncertaintiesE;
+    std::tuple<double,double> result = uncertainty_tools::computeVectorMagnitudeAndUncertainty(componentsE, uncertaintiesE);
+    FAIL() << "Exception not thrown when provided with empty lists";
+  } catch (const std::invalid_argument& e) {
+    // PASS
+  } catch (const std::exception& e) {
+    FAIL() << "Exception thrown not of expected type std::invalid_argument. Instead: " << e.what();
+  }
+
+  // Unequal Sizes
+  try {
+    components.push_back(0.1);
+    std::tuple<double,double> result = uncertainty_tools::computeVectorMagnitudeAndUncertainty(components, uncertainties);
+    FAIL() << "Exception not thrown when provided with empty lists";
+  } catch (const std::invalid_argument& e) {
+    // PASS
+  } catch (const std::exception& e) {
+    FAIL() << "Exception thrown not of expected type std::invalid_argument. Instead: " << e.what();
+  }
+}
+
+// Run all the tests
+int main(int argc, char **argv) {
+    testing::InitGoogleMock(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
This PR adds a new package called uncertainty_tools which is meant to contain helpful functions for dealing with uncertainty. At the moment is contains one function which combines the uncertainties of vector components into their resultant and a combined uncertainty value

In addition, the CARMANodeHandle package was updated to have a constructor which takes in a regular node handle. 