### PR TITLE
Remove non-ros dependencies in package xml for sigpack

### DIFF
--- a/sigpack/package.xml
+++ b/sigpack/package.xml
@@ -22,6 +22,4 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>fftw3</depend>
-  <depend>Armadillo</depend> 
 </package>


### PR DESCRIPTION
When building CARMAPlatform rosdep is trying to install non-ros packages that were listed in the package xml of sigpack and failing when they are not found. I haven't been able to find a way around that so I am removing them for now. The packages are listed in the CMakeList.txt as required to build still. 