### PR TITLE
updated (C) info

### DIFF
--- a/carma_utils/include/carma_utils/CARMANodeHandle.h
+++ b/carma_utils/include/carma_utils/CARMANodeHandle.h
@@ -1,7 +1,7 @@
 #ifndef CARMA_UTILS_CARMA_NODE_HANDLE_H
 #define CARMA_UTILS_CARMA_NODE_HANDLE_H
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/carma_utils/include/carma_utils/CARMAUtils.h
+++ b/carma_utils/include/carma_utils/CARMAUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/carma_utils/src/carma_utils/CARMANodeHandle.cpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License") { you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/carma_utils/src/carma_utils/CARMANodeHandle.tpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.tpp
@@ -1,6 +1,6 @@
 #ifdef CARMA_UTILS_CARMA_NODE_HANDLE_H
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License") { you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/carma_utils/src/carma_utils/CARMAUtils.cpp
+++ b/carma_utils/src/carma_utils/CARMAUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
+++ b/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License") { you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/carma_utils/test/carma_utils/CallRecorder.h
+++ b/carma_utils/test/carma_utils/CallRecorder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License") { you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cav_driver_utils/include/driver_wrapper/driver_wrapper.h
+++ b/cav_driver_utils/include/driver_wrapper/driver_wrapper.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2019 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cav_driver_utils/src/driver_wrapper/driver_wrapper.cpp
+++ b/cav_driver_utils/src/driver_wrapper/driver_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/uncertainty_tools/include/uncertainty_tools/uncertainty_tools.h
+++ b/uncertainty_tools/include/uncertainty_tools/uncertainty_tools.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/uncertainty_tools/src/uncertainty_tools/uncertainty_tools.cpp
+++ b/uncertainty_tools/src/uncertainty_tools/uncertainty_tools.cpp
@@ -1,6 +1,6 @@
 #pragma once
 /*
- * Copyright (C) 2018-2019 LEIDOS.
+ * Copyright (C) 2018-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/uncertainty_tools/test/uncertainty_tools/uncertainty_tools_test.cpp
+++ b/uncertainty_tools/test/uncertainty_tools/uncertainty_tools_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
Updated copyright info per CAR-1532. Could not test via build since there is no docker image for this repo. Copyright updates can be confirmed by checking the diff.