### PR TITLE
add shutdown node

### DIFF
--- a/driver_shutdown/CMakeLists.txt
+++ b/driver_shutdown/CMakeLists.txt
@@ -96,7 +96,6 @@ install(DIRECTORY include/
 # Mark other files for installation (e.g. launch and bag files, etc.)
 install(DIRECTORY
   launch
-  config
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/driver_shutdown/CMakeLists.txt
+++ b/driver_shutdown/CMakeLists.txt
@@ -1,0 +1,102 @@
+# Copyright (C) 2018-2020 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+cmake_minimum_required(VERSION 2.8.3)
+project(driver_shutdown)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  carma_utils
+  cav_msgs
+  roscpp
+  std_msgs
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system)
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+   INCLUDE_DIRS include
+   CATKIN_DEPENDS carma_utils cav_msgs roscpp std_msgs
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+add_executable(${PROJECT_NAME}
+  src/driver_shutdown.cpp
+  src/main.cpp
+)
+
+
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME}
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+
+#############
+## Install ##
+#############
+
+## Mark executables and/or libraries for installation
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Mark cpp header files for installation
+install(DIRECTORY include/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.hpp"
+  PATTERN ".svn" EXCLUDE
+)
+
+# Mark other files for installation (e.g. launch and bag files, etc.)
+install(DIRECTORY
+  launch
+  config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+

--- a/driver_shutdown/CMakeLists.txt
+++ b/driver_shutdown/CMakeLists.txt
@@ -89,8 +89,6 @@ install(TARGETS ${PROJECT_NAME}
 # Mark cpp header files for installation
 install(DIRECTORY include/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.hpp"
-  PATTERN ".svn" EXCLUDE
 )
 
 # Mark other files for installation (e.g. launch and bag files, etc.)

--- a/driver_shutdown/include/driver_shutdown.h
+++ b/driver_shutdown/include/driver_shutdown.h
@@ -1,0 +1,44 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <carma_utils/CARMAUtils.h>
+
+
+namespace driver_shutdown
+{
+    class DriverShutdown
+    {
+        public:
+
+            /*!
+             * \brief Begin normal execution of driver shutdown node.
+             * 
+             * \return The exit status of this program
+             */
+            void run();
+
+        private:
+
+            // node handles
+            ros::CARMANodeHandle nh_, pnh_;
+
+            void initialize();
+
+    
+    };
+}

--- a/driver_shutdown/launch/driver_shutdown.launch
+++ b/driver_shutdown/launch/driver_shutdown.launch
@@ -1,0 +1,26 @@
+<!--
+
+  Copyright (C) 2018-2020 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+ 
+Primary launch file for driver shutdown node
+Loads parameters and configures logging for the node
+ 
+-->
+<launch>
+<!-- Driver Shutdown Node -->
+<node pkg="driver_shutdown" type="driver_shutdown" name="driver_shutdown"/>
+</launch>

--- a/driver_shutdown/package.xml
+++ b/driver_shutdown/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>driver_shutdown</name>
+  <version>3.3.0</version>
+  <description>The node is used to shutdown the drivers</description>
+  <maintainer email="CARMA@dot.gov">carma</maintainer>
+  <license>Apache 2.0 License</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>carma_utils</depend>
+  <depend>cav_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+</package>

--- a/driver_shutdown/src/driver_shutdown.cpp
+++ b/driver_shutdown/src/driver_shutdown.cpp
@@ -1,0 +1,40 @@
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "driver_shutdown.h"
+
+namespace driver_shutdown
+{
+
+    void DriverShutdown::initialize()
+    {
+        // init node handles
+        nh_ = ros::CARMANodeHandle();
+        pnh_ = ros::CARMANodeHandle("~");
+
+    }
+
+    void DriverShutdown::run()
+    {
+    	initialize();
+        ros::CARMANodeHandle::setSpinRate(10.0);
+        ros::CARMANodeHandle::spin();
+
+    }
+    
+
+}

--- a/driver_shutdown/src/main.cpp
+++ b/driver_shutdown/src/main.cpp
@@ -1,0 +1,11 @@
+
+#include <ros/ros.h>
+#include "driver_shutdown.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "driver_shutdown");
+    driver_shutdown::DriverShutdown node;
+    node.run();
+    return 0;
+};


### PR DESCRIPTION
A shutdown node is developed to subscribe to system alert and shutdown drivers when required.
Addressing CARMAPlatform github issue 
usdot-fhwa-stol/CARMAPlatform#460